### PR TITLE
fix(pnpm): disable frozen lockfile

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -146,7 +146,7 @@ runs:
           yarn install
         elif [ "${{ inputs.package-manager }}" = "pnpm" ]; then
           npm i -g "pnpm@${{ inputs.package-manager-version }}"
-          pnpm install
+          pnpm install --no-frozen-lockfile
         else
           npm i -g "npm@${{ inputs.package-manager-version }}"
           npm install


### PR DESCRIPTION
Hey! I hit a bug in the GitHub Action when using pnpm:

```
 ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up-to-date with packages/config/package.json
Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"
Error: Process completed with exit code 1.
```

**How to fix it:**
In CI environments, pnpm always runs with the `--frozen-lockfile` option. In this case, we attempt to run `pnpm install` to update the lockfile, so we need to be explicit about it, and as the error tells us, we need to use the `--no-frozen-lockfile` option.